### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/index.html
+++ b/index.html
@@ -38,7 +38,16 @@
   <!-- <link rel="stylesheet" href="css/brands-extended.css"> -->
   <!-- Learn more at https://github.com/sethcottle/littlelink-extended. 
          Remove comments if you've added LittleLink Extended dependencies -->
-
+  
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MEPG30J56X"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+  
+    gtag('config', 'G-MEPG30J56X');
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
Potential fix for [https://github.com/y-hbb/littlelink/security/code-scanning/1](https://github.com/y-hbb/littlelink/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
1. `actions/checkout` requires `contents: read` to fetch the repository code.
2. `peaceiris/actions-gh-pages` requires `contents: write` to push the built files to the `gh-pages` branch.

We will set `contents: write` at the workflow level to cover these needs. This ensures the workflow has only the necessary permissions and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
